### PR TITLE
Hotfix to drivetrain motors' direction issue

### DIFF
--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -44,9 +44,6 @@ public class RobotMap {
     public static final DoubleSolenoid gearShifter = new DoubleSolenoid(0, 1);
   
     public static void init() {
-        // Invert victors due to gearbox config
-        lVictor.setInverted(true);
-        rVictor.setInverted(true);
         // Set the motors to follow
         lTalon1.follow(lVictor);
         lTalon2.follow(lVictor);


### PR DESCRIPTION
The victors were incorrectly inverted which caused the gearboxes to lock
into each other.