### PR TITLE
Add commands to turn the robot in place

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -12,7 +12,7 @@ import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import frc.robot.misc.FollowTrajectory;
+import frc.robot.commands.FollowTrajectory;
 import frc.robot.subsystems.Drivetrain;
 import robot.pathfinder.core.TrajectoryParams;
 import robot.pathfinder.core.Waypoint;

--- a/src/main/java/frc/robot/commands/FollowTrajectory.java
+++ b/src/main/java/frc/robot/commands/FollowTrajectory.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.misc;
+package frc.robot.commands;
 
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.command.Command;
@@ -82,8 +82,9 @@ public class FollowTrajectory extends Command {
     }
 
     // Make this return true when this Command no longer needs to run execute()
+    // Note we made this method public! This is so that Commands that wrap around this one have an easier time.
     @Override
-    protected boolean isFinished() {
+    public boolean isFinished() {
         return !follower.isRunning();
     }
 

--- a/src/main/java/frc/robot/commands/RotateToAngle.java
+++ b/src/main/java/frc/robot/commands/RotateToAngle.java
@@ -1,0 +1,75 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+import frc.robot.RobotMap;
+import robot.pathfinder.core.trajectory.TankDriveTrajectory;
+import robot.pathfinder.core.trajectory.TrajectoryGenerator;
+
+/**
+ * Rotates the robot in place a certain number of degrees in a specified direction.
+ * This command uses the {@link frc.robot.commands.FollowTrajectory FollowTrajectory} command internally
+ * and thus requires RobotPathfinder to be properly tuned.
+ */
+public class RotateToAngle extends Command {
+
+    /**
+     * The direction to turn in.
+     */
+    public enum Direction {
+        LEFT, RIGHT;
+    }
+
+    final TankDriveTrajectory trajectory;
+    final FollowTrajectory followerCommand;
+
+    /**
+     * Creates a new rotate to angle command.
+     * @param angle The angle, in degrees, to turn
+     * @param direction The direction to turn in
+     */
+    public RotateToAngle(double angle, Direction direction) {
+        // Use requires() here to declare subsystem dependencies
+        // eg. requires(chassis);
+        requires(Robot.drivetrain);
+
+        // Use a RobotPathfinder trajectory here to save time and improve accuracy with the already tuned PIDs
+        trajectory = TrajectoryGenerator.generateRotationTank(RobotMap.specs, direction == Direction.LEFT ? Math.toRadians(angle) : Math.toRadians(-angle));
+        followerCommand = new FollowTrajectory(trajectory);
+    }
+
+    // Called just before this Command runs the first time
+    @Override
+    protected void initialize() {
+        followerCommand.start();
+    }
+
+    // Called repeatedly when this Command is scheduled to run
+    @Override
+    protected void execute() {
+    }
+
+    // Make this return true when this Command no longer needs to run execute()
+    @Override
+    protected boolean isFinished() {
+        return followerCommand.isFinished();
+    }
+
+    // Called once after isFinished returns true
+    @Override
+    protected void end() {
+    }
+
+    // Called when another command which requires one or more of the same
+    // subsystems is scheduled to run
+    @Override
+    protected void interrupted() {
+    }
+}

--- a/src/main/java/frc/robot/commands/RotateToAngleGyro.java
+++ b/src/main/java/frc/robot/commands/RotateToAngleGyro.java
@@ -1,0 +1,99 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import static frc.robot.subsystems.Drivetrain.constrainAngle;
+
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+/**
+ * Uses the navX gyro reading to turn the robot a certain amount of degrees.
+ */
+public class RotateToAngleGyro extends Command {
+
+    public enum Direction {
+        LEFT, RIGHT;
+    }
+
+    private double angle;
+    private final Direction direction;
+    private final double speed;
+    
+    private double startingHeading;
+
+    public RotateToAngleGyro(double angle, Direction direction) {
+        requires(Robot.drivetrain);
+        // Left is positive
+        this.angle = angle;
+        this.direction = direction;
+        speed = 1.0;
+    }
+
+    public RotateToAngleGyro(double angle, Direction direction, double speed) {
+        requires(Robot.drivetrain);
+        // Left is positive
+        this.angle = angle;
+        this.speed = speed;
+        this.direction = direction;
+    }
+
+    public void setAngle(double angle) {
+        this.angle = angle;
+    }
+
+    private NeutralMode originalMode;
+
+    // Called just before this Command runs the first time
+    @Override
+    protected void initialize() {
+        // Set the drive motors into brake mode
+        originalMode = Robot.drivetrain.getNeutralMode();
+        Robot.drivetrain.setNeutralMode(NeutralMode.Brake);
+
+        if(direction == Direction.LEFT) {
+            Robot.drivetrain.setMotors(-speed, speed);
+        }
+        else {
+            Robot.drivetrain.setMotors(speed, -speed);
+        }
+    }
+
+    // Called repeatedly when this Command is scheduled to run
+    @Override
+    protected void execute() {
+    }
+
+    // Make this return true when this Command no longer needs to run execute()
+    @Override
+    protected boolean isFinished() {
+        // The heading from the navX may need to be reversed
+        if(direction == Direction.LEFT) {
+            return constrainAngle(Robot.drivetrain.getHeading() - startingHeading) >= angle;
+        }
+        else {
+            return constrainAngle(Robot.drivetrain.getHeading() - startingHeading) <= -angle;
+        }
+    }
+
+    // Called once after isFinished returns true
+    @Override
+    protected void end() {
+        Robot.drivetrain.setMotors(0, 0);
+        Robot.drivetrain.setNeutralMode(originalMode);
+    }
+
+    // Called when another command which requires one or more of the same
+    // subsystems is scheduled to run
+    @Override
+    protected void interrupted() {
+        end();
+    }
+}


### PR DESCRIPTION
Add the `RotateToAngle` command and `RotateToAngleGyro` command. Both commands rotate the robot in place in a certain direction for a certain angle. One uses RobotPathfinder, the other one uses only the gyro.

Additionally, the incorrectly placed `FollowTrajectory` command has also been moved from package `frc.robot.misc` to `frc.robot.commands`.